### PR TITLE
Add Instance ID to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "instance_id" {
-  value = "${aws.instance.default.id}"
+  value = "${aws_instance.default.id}"
 }
 
 output "ssh_user" {


### PR DESCRIPTION
## what
* Add `instance_id` to outputs

## why
* Better integration with other AWS resources