### PR TITLE
Add security customizations to the bastion instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ Available targets:
 | ingress\_security\_groups | AWS security group IDs allowed ingress to instance | `list(string)` | `[]` | no |
 | instance\_type | Elastic cache instance type | `string` | `"t2.micro"` | no |
 | key\_name | Key name | `string` | `""` | no |
-| metadata\_http\_endpoint | Whether the metadata service is available | `bool` | `true` | no |
+| metadata\_http\_endpoint\_enabled | Whether the metadata service is available | `bool` | `true` | no |
 | metadata\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit (between 1 and 64) for instance metadata requests. | `number` | `1` | no |
 | metadata\_http\_tokens\_required | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2. | `bool` | `false` | no |
 | name | Name  (e.g. `app` or `bastion`) | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | n/a | yes |
-| root\_block\_device\_encrypted | Whether to encrypt to root block device | `bool` | `false` | no |
+| root\_block\_device\_encrypted | Whether to encrypt the root block device | `bool` | `false` | no |
 | root\_block\_device\_volume\_size | The volume size (in GiB) to provision for the root block device. It cannot be smaller than the AMI it refers to. | `number` | `8` | no |
 | security\_groups | AWS security group IDs associated with instance | `list(string)` | `[]` | no |
 | ssh\_user | Default SSH user for this AMI. e.g. `ec2user` for Amazon Linux and `ubuntu` for Ubuntu systems | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -105,8 +106,13 @@ Available targets:
 | ingress\_security\_groups | AWS security group IDs allowed ingress to instance | `list(string)` | `[]` | no |
 | instance\_type | Elastic cache instance type | `string` | `"t2.micro"` | no |
 | key\_name | Key name | `string` | `""` | no |
+| metadata\_http\_endpoint | Whether the metadata service is available | `bool` | `true` | no |
+| metadata\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit (between 1 and 64) for instance metadata requests. | `number` | `1` | no |
+| metadata\_http\_tokens\_required | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2. | `bool` | `false` | no |
 | name | Name  (e.g. `app` or `bastion`) | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | n/a | yes |
+| root\_block\_device\_encrypted | Whether to encrypt to root block device | `bool` | `false` | no |
+| root\_block\_device\_volume\_size | The volume size (in GiB) to provision for the root block device. It cannot be smaller than the AMI it refers to. | `number` | `8` | no |
 | security\_groups | AWS security group IDs associated with instance | `list(string)` | `[]` | no |
 | ssh\_user | Default SSH user for this AMI. e.g. `ec2user` for Amazon Linux and `ubuntu` for Ubuntu systems | `string` | n/a | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | n/a | yes |
@@ -128,6 +134,7 @@ Available targets:
 | security\_group\_id | Security group ID |
 | ssh\_user | SSH user |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -26,8 +27,13 @@
 | ingress\_security\_groups | AWS security group IDs allowed ingress to instance | `list(string)` | `[]` | no |
 | instance\_type | Elastic cache instance type | `string` | `"t2.micro"` | no |
 | key\_name | Key name | `string` | `""` | no |
+| metadata\_http\_endpoint | Whether the metadata service is available | `bool` | `true` | no |
+| metadata\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit (between 1 and 64) for instance metadata requests. | `number` | `1` | no |
+| metadata\_http\_tokens\_required | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2. | `bool` | `false` | no |
 | name | Name  (e.g. `app` or `bastion`) | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | n/a | yes |
+| root\_block\_device\_encrypted | Whether to encrypt to root block device | `bool` | `false` | no |
+| root\_block\_device\_volume\_size | The volume size (in GiB) to provision for the root block device. It cannot be smaller than the AMI it refers to. | `number` | `8` | no |
 | security\_groups | AWS security group IDs associated with instance | `list(string)` | `[]` | no |
 | ssh\_user | Default SSH user for this AMI. e.g. `ec2user` for Amazon Linux and `ubuntu` for Ubuntu systems | `string` | n/a | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | n/a | yes |
@@ -49,3 +55,4 @@
 | security\_group\_id | Security group ID |
 | ssh\_user | SSH user |
 
+<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,12 +27,12 @@
 | ingress\_security\_groups | AWS security group IDs allowed ingress to instance | `list(string)` | `[]` | no |
 | instance\_type | Elastic cache instance type | `string` | `"t2.micro"` | no |
 | key\_name | Key name | `string` | `""` | no |
-| metadata\_http\_endpoint | Whether the metadata service is available | `bool` | `true` | no |
+| metadata\_http\_endpoint\_enabled | Whether the metadata service is available | `bool` | `true` | no |
 | metadata\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit (between 1 and 64) for instance metadata requests. | `number` | `1` | no |
 | metadata\_http\_tokens\_required | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2. | `bool` | `false` | no |
 | name | Name  (e.g. `app` or `bastion`) | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | n/a | yes |
-| root\_block\_device\_encrypted | Whether to encrypt to root block device | `bool` | `false` | no |
+| root\_block\_device\_encrypted | Whether to encrypt the root block device | `bool` | `false` | no |
 | root\_block\_device\_volume\_size | The volume size (in GiB) to provision for the root block device. It cannot be smaller than the AMI it refers to. | `number` | `8` | no |
 | security\_groups | AWS security group IDs associated with instance | `list(string)` | `[]` | no |
 | ssh\_user | Default SSH user for this AMI. e.g. `ec2user` for Amazon Linux and `ubuntu` for Ubuntu systems | `string` | n/a | yes |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -25,3 +25,7 @@ user_data = [
 security_groups = []
 
 ingress_security_groups = []
+
+root_block_device_encrypted = true
+
+metadata_http_tokens_required = true

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -103,3 +103,33 @@ variable "allowed_cidr_blocks" {
     "0.0.0.0/0",
   ]
 }
+
+variable "root_block_device_encrypted" {
+  type        = bool
+  default     = false
+  description = "Whether to encrypt to root block device"
+}
+
+variable "root_block_device_volume_size" {
+  type        = number
+  default     = 8
+  description = "The volume size (in GiB) to provision for the root block device. It cannot be smaller than the AMI it refers to."
+}
+
+variable "metadata_http_endpoint" {
+  type        = bool
+  default     = true
+  description = "Whether the metadata service is available"
+}
+
+variable "metadata_http_put_response_hop_limit" {
+  type        = number
+  default     = 1
+  description = "The desired HTTP PUT response hop limit (between 1 and 64) for instance metadata requests."
+}
+
+variable "metadata_http_tokens_required" {
+  type        = bool
+  default     = false
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2."
+}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -107,7 +107,7 @@ variable "allowed_cidr_blocks" {
 variable "root_block_device_encrypted" {
   type        = bool
   default     = false
-  description = "Whether to encrypt to root block device"
+  description = "Whether to encrypt the root block device"
 }
 
 variable "root_block_device_volume_size" {
@@ -116,7 +116,7 @@ variable "root_block_device_volume_size" {
   description = "The volume size (in GiB) to provision for the root block device. It cannot be smaller than the AMI it refers to."
 }
 
-variable "metadata_http_endpoint" {
+variable "metadata_http_endpoint_enabled" {
   type        = bool
   default     = true
   description = "Whether the metadata service is available"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -101,10 +101,21 @@ resource "aws_instance" "default" {
   subnet_id = var.subnets[0]
 
   tags = module.label.tags
+
+  metadata_options {
+    http_endpoint               = (var.metadata_http_endpoint) ? "enabled" : "disabled"
+    http_put_response_hop_limit = var.metadata_http_put_response_hop_limit
+    http_tokens                 = (var.metadata_http_tokens_required) ? "required" : "optional"
+  }
+
+  root_block_device {
+    encrypted   = var.root_block_device_encrypted
+    volume_size = var.root_block_device_volume_size
+  }
 }
 
 module "dns" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
   enabled = var.enabled && var.zone_id != "" ? true : false
   name    = var.name
   zone_id = var.zone_id

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ resource "aws_instance" "default" {
   tags = module.label.tags
 
   metadata_options {
-    http_endpoint               = (var.metadata_http_endpoint) ? "enabled" : "disabled"
+    http_endpoint               = (var.metadata_http_endpoint_enabled) ? "enabled" : "disabled"
     http_put_response_hop_limit = var.metadata_http_put_response_hop_limit
     http_tokens                 = (var.metadata_http_tokens_required) ? "required" : "optional"
   }
@@ -122,4 +122,3 @@ module "dns" {
   ttl     = 60
   records = aws_instance.default.*.public_dns
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -102,3 +102,33 @@ variable "allowed_cidr_blocks" {
     "0.0.0.0/0",
   ]
 }
+
+variable "root_block_device_encrypted" {
+  type        = bool
+  default     = false
+  description = "Whether to encrypt to root block device"
+}
+
+variable "root_block_device_volume_size" {
+  type        = number
+  default     = 8
+  description = "The volume size (in GiB) to provision for the root block device. It cannot be smaller than the AMI it refers to."
+}
+
+variable "metadata_http_endpoint" {
+  type        = bool
+  default     = true
+  description = "Whether the metadata service is available"
+}
+
+variable "metadata_http_put_response_hop_limit" {
+  type        = number
+  default     = 1
+  description = "The desired HTTP PUT response hop limit (between 1 and 64) for instance metadata requests."
+}
+
+variable "metadata_http_tokens_required" {
+  type        = bool
+  default     = false
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -106,7 +106,7 @@ variable "allowed_cidr_blocks" {
 variable "root_block_device_encrypted" {
   type        = bool
   default     = false
-  description = "Whether to encrypt to root block device"
+  description = "Whether to encrypt the root block device"
 }
 
 variable "root_block_device_volume_size" {
@@ -115,7 +115,7 @@ variable "root_block_device_volume_size" {
   description = "The volume size (in GiB) to provision for the root block device. It cannot be smaller than the AMI it refers to."
 }
 
-variable "metadata_http_endpoint" {
+variable "metadata_http_endpoint_enabled" {
   type        = bool
   default     = true
   description = "Whether the metadata service is available"


### PR DESCRIPTION
## what
* Added the ability to encrypt the root block device, `off` by default.
* Added the ability to change the size of the root block device
* Added the ability to change the HTTP Metadata endpoint settings (e.g. disable it, force it to IMSv2)
* Example modified to encrypt the EBS + turn off IMSv2 per recommendations

## why
* Checkov recommends to have the root block device encrypted and IMSv1 disabled. See references below for the rationale behind this recommendation.
With the changes in this PR one can configure their Bastion to follow these recommendations.

## references
* CKV_AWS_79: "Ensure Instance Metadata Service Version 1 is not enabled". Rationale behind this can be found in this [AWS blog post](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/).
* CKV_AWS_8: "Ensure all data stored in the Launch configuration EBS is securely encrypted" (https://docs.bridgecrew.io/docs/general_13)

