### PR TITLE
Allow toggleable public IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Available targets:
 |------|-------------|------|---------|:--------:|
 | allowed\_cidr\_blocks | A list of CIDR blocks allowed to connect | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | ami | AMI to use | `string` | `"ami-efd0428f"` | no |
+| associate\_public\_ip\_address | Whether to associate a public IP to the instance. | `bool` | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | enabled | When disabled, module will not create any resources | `bool` | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,6 +21,7 @@
 |------|-------------|------|---------|:--------:|
 | allowed\_cidr\_blocks | A list of CIDR blocks allowed to connect | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | ami | AMI to use | `string` | `"ami-efd0428f"` | no |
+| associate\_public\_ip\_address | Whether to associate a public IP to the instance. | `bool` | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | enabled | When disabled, module will not create any resources | `bool` | `true` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -29,3 +29,5 @@ ingress_security_groups = []
 root_block_device_encrypted = true
 
 metadata_http_tokens_required = true
+
+associate_public_ip_address = true

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -133,3 +133,9 @@ variable "metadata_http_tokens_required" {
   default     = false
   description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2."
 }
+
+variable "associate_public_ip_address" {
+  type        = bool
+  default     = true
+  description = "Whether to associate public IP to the instance."
+}

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "aws_instance" "default" {
   vpc_security_group_ids = compact(concat(aws_security_group.default.*.id, var.security_groups))
 
   iam_instance_profile        = aws_iam_instance_profile.default[0].name
-  associate_public_ip_address = true
+  associate_public_ip_address = var.associate_public_ip_address
 
   key_name = var.key_name
 

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,9 @@ variable "metadata_http_tokens_required" {
   default     = false
   description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2."
 }
+
+variable "associate_public_ip_address" {
+  type        = bool
+  default     = true
+  description = "Whether to associate a public IP to the instance."
+}


### PR DESCRIPTION
## what
* Adds a flag to turn off public IP association

## why
* It may not always be desirable to have the Bastion host reachable from the internet (e.g. when using SSH over Session Manager)
