### PR TITLE
Fix format of outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "instance_id" {
-  value       = aws_instance.default.*.id
+  value       = join("", aws_instance.default.*.id)
   description = "Instance ID"
 }
 
@@ -9,22 +9,22 @@ output "ssh_user" {
 }
 
 output "security_group_id" {
-  value       = aws_security_group.default.*.id
+  value       = join("", aws_security_group.default.*.id)
   description = "Security group ID"
 }
 
 output "role" {
-  value       = aws_iam_role.default.*.name
+  value       = join("", aws_iam_role.default.*.name)
   description = "Name of AWS IAM Role associated with the instance"
 }
 
 output "public_ip" {
-  value       = aws_instance.default.*.public_ip
+  value       = join("", aws_instance.default.*.public_ip)
   description = "Public IP of the instance (or EIP)"
 }
 
 output "private_ip" {
-  value       = aws_instance.default.*.private_ip
+  value       = join("", aws_instance.default.*.private_ip)
   description = "Private IP of the instance"
 }
 


### PR DESCRIPTION
What

* Fix format of outputs so no trailing 0 is needed

Why

* Currently I have to suffix the `instance_id` with a 0: `module.bastion.instance_id[0]`. This PR will fix this.
