### PR TITLE
Update default AMI ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | allowed\_cidr\_blocks | A list of CIDR blocks allowed to connect | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| ami | AMI to use | `string` | `"ami-efd0428f"` | no |
+| ami | AMI to use | `string` | `"ami-084ef34fdfdd7384c"` | no |
 | associate\_public\_ip\_address | Whether to associate a public IP to the instance. | `bool` | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,7 +20,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | allowed\_cidr\_blocks | A list of CIDR blocks allowed to connect | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| ami | AMI to use | `string` | `"ami-efd0428f"` | no |
+| ami | AMI to use | `string` | `"ami-084ef34fdfdd7384c"` | no |
 | associate\_public\_ip\_address | Whether to associate a public IP to the instance. | `bool` | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |

--- a/examples/latest-ami/fixtures.us-east-2.tfvars
+++ b/examples/latest-ami/fixtures.us-east-2.tfvars
@@ -1,0 +1,31 @@
+region = "us-east-2"
+
+availability_zones = ["us-east-2a", "us-east-2b"]
+
+namespace = "eg"
+
+stage = "test"
+
+name = "ec2-bastion"
+
+instance_type = "t3a.nano"
+
+ssh_user = "ubuntu"
+
+ssh_key_path = "./secrets"
+
+generate_ssh_key = true
+
+user_data = [
+  "apt-get install -y postgresql-client-common"
+]
+
+security_groups = []
+
+ingress_security_groups = []
+
+root_block_device_encrypted = true
+
+metadata_http_tokens_required = true
+
+associate_public_ip_address = true

--- a/examples/latest-ami/main.tf
+++ b/examples/latest-ami/main.tf
@@ -1,0 +1,76 @@
+provider "aws" {
+  region = var.region
+}
+
+module "vpc" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.1"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  cidr_block = "172.16.0.0/16"
+}
+
+module "subnets" {
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.26.0"
+  availability_zones   = var.availability_zones
+  namespace            = var.namespace
+  stage                = var.stage
+  name                 = var.name
+  vpc_id               = module.vpc.vpc_id
+  igw_id               = module.vpc.igw_id
+  cidr_block           = module.vpc.vpc_cidr_block
+  nat_gateway_enabled  = false
+  nat_instance_enabled = false
+}
+
+module "aws_key_pair" {
+  source              = "git::https://github.com/cloudposse/terraform-aws-key-pair.git?ref=tags/0.13.1"
+  namespace           = var.namespace
+  stage               = var.stage
+  name                = var.name
+  attributes          = ["ssh", "key"]
+  ssh_public_key_path = var.ssh_key_path
+  generate_ssh_key    = var.generate_ssh_key
+}
+
+# Retrieves the most recent Ubuntu 20.04 AMI
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+module "ec2_bastion" {
+  source = "../../"
+
+  enabled = var.enabled
+
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
+  attributes = var.attributes
+
+  security_groups         = compact(concat([module.vpc.vpc_default_security_group_id], var.security_groups))
+  ingress_security_groups = var.ingress_security_groups
+  subnets                 = module.subnets.public_subnet_ids
+  ssh_user                = var.ssh_user
+  key_name                = module.aws_key_pair.key_name
+
+  user_data = var.user_data
+
+  vpc_id = module.vpc.vpc_id
+}

--- a/examples/latest-ami/outputs.tf
+++ b/examples/latest-ami/outputs.tf
@@ -1,0 +1,49 @@
+output "instance_id" {
+  value       = module.ec2_bastion.instance_id
+  description = "Instance ID"
+}
+
+output "ssh_user" {
+  value       = var.ssh_user
+  description = "SSH user"
+}
+
+output "security_group_id" {
+  value       = module.ec2_bastion.security_group_id
+  description = "Security group ID"
+}
+
+output "role" {
+  value       = module.ec2_bastion.role
+  description = "Name of AWS IAM Role associated with the instance"
+}
+
+output "public_ip" {
+  value       = module.ec2_bastion.public_ip
+  description = "Public IP of the instance (or EIP)"
+}
+
+output "private_ip" {
+  value       = module.ec2_bastion.private_ip
+  description = "Private IP of the instance"
+}
+
+output "public_subnet_cidrs" {
+  value = module.subnets.public_subnet_cidrs
+}
+
+output "private_subnet_cidrs" {
+  value = module.subnets.private_subnet_cidrs
+}
+
+output "vpc_cidr" {
+  value = module.vpc.vpc_cidr_block
+}
+
+output "key_name" {
+  value = module.aws_key_pair.key_name
+}
+
+output "public_key" {
+  value = module.aws_key_pair.public_key
+}

--- a/examples/latest-ami/variables.tf
+++ b/examples/latest-ami/variables.tf
@@ -58,12 +58,6 @@ variable "instance_type" {
   description = "Elastic cache instance type"
 }
 
-variable "ami" {
-  type        = string
-  default     = "ami-084ef34fdfdd7384c"
-  description = "AMI to use"
-}
-
 variable "user_data" {
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "instance_type" {
 
 variable "ami" {
   type        = string
-  default     = "ami-efd0428f"
+  default     = "ami-084ef34fdfdd7384c"
   description = "AMI to use"
 }
 


### PR DESCRIPTION
## what
* Update the default / example AMI ID to the most recent version
* Added an example on how to always obtain the latest AMI ID within the Terraform configuration

## why
* Out of the box (without an explicit AMI ID set) the provisioning will fail

## references
* closes https://github.com/cloudposse/terraform-aws-ec2-bastion-server/issues/37

