### PR TITLE
Use private DNS record when not associating public IP

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,5 +112,5 @@ module "dns" {
   name    = module.this.name
   zone_id = var.zone_id
   ttl     = 60
-  records = var.associate_public_address ? aws_instance.default.*.public_dns : aws_instance.default.*.private_dns
+  records = var.associate_public_ip_address ? aws_instance.default.*.public_dns : aws_instance.default.*.private_dns
 }

--- a/main.tf
+++ b/main.tf
@@ -120,5 +120,5 @@ module "dns" {
   name    = var.name
   zone_id = var.zone_id
   ttl     = 60
-  records = aws_instance.default.*.public_dns
+  records = var.associate_public_address ? aws_instance.default.*.public_dns : aws_instance.default.*.private_dns
 }


### PR DESCRIPTION
## What
* Use private DNS record when `var.associate_public_address = false`.

## Why
* When not associating public IP the record would be empty. This fixes that.
