### PR TITLE
Fix typo in the description of instance_type var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+<!-- markdownlint-disable -->
 # terraform-aws-ec2-bastion-server [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-ec2-bastion-server.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-ec2-bastion-server) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-ec2-bastion-server.svg)](https://github.com/cloudposse/terraform-aws-ec2-bastion-server/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+<!-- markdownlint-restore -->
 
 [![README Header][readme_header_img]][readme_header_link]
 
@@ -109,7 +111,7 @@ Available targets:
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | ingress\_security\_groups | AWS security group IDs allowed ingress to instance | `list(string)` | `[]` | no |
-| instance\_type | Elastic cache instance type | `string` | `"t2.micro"` | no |
+| instance\_type | Bastion instance type | `string` | `"t2.micro"` | no |
 | key\_name | Key name | `string` | `""` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | metadata\_http\_endpoint\_enabled | Whether the metadata service is available | `bool` | `true` | no |
@@ -290,8 +292,10 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
+<!-- markdownlint-disable -->
 |  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Bobby Larson][karma0_avatar]][karma0_homepage]<br/>[Bobby Larson][karma0_homepage] |
 |---|---|---|---|
+<!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,7 +30,7 @@
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | ingress\_security\_groups | AWS security group IDs allowed ingress to instance | `list(string)` | `[]` | no |
-| instance\_type | Elastic cache instance type | `string` | `"t2.micro"` | no |
+| instance\_type | Bastion instance type | `string` | `"t2.micro"` | no |
 | key\_name | Key name | `string` | `""` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | metadata\_http\_endpoint\_enabled | Whether the metadata service is available | `bool` | `true` | no |

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -17,7 +17,7 @@ variable "zone_id" {
 variable "instance_type" {
   type        = string
   default     = "t2.micro"
-  description = "Elastic cache instance type"
+  description = "Bastion instance type"
 }
 
 variable "ami" {

--- a/examples/latest-ami/variables.tf
+++ b/examples/latest-ami/variables.tf
@@ -55,7 +55,7 @@ variable "zone_id" {
 variable "instance_type" {
   type        = string
   default     = "t2.micro"
-  description = "Elastic cache instance type"
+  description = "Bastion instance type"
 }
 
 variable "user_data" {

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "zone_id" {
 variable "instance_type" {
   type        = string
   default     = "t2.micro"
-  description = "Elastic cache instance type"
+  description = "Bastion instance type"
 }
 
 variable "ami" {


### PR DESCRIPTION
## what
- Fix typo in the description of `instance_type` var

## why
- Avoids confusion

## references
