### PR TITLE
Conditionally configure security group ingress

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,12 +46,15 @@ resource "aws_security_group" "default" {
     cidr_blocks = var.allowed_cidr_blocks
   }
 
-  ingress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = -1
-    description     = "Allow ingress to groups listed in var.ingress_security"
-    security_groups = var.ingress_security_groups
+  dynamic "ingress" {
+    for_each = length(var.ingress_security_groups) > 0 ? [1] : []
+    content {
+      from_port       = 0
+      to_port         = 0
+      protocol        = -1
+      description     = "Allow ingress to groups listed in var.ingress_security"
+      security_groups = var.ingress_security_groups
+    }
   }
 
   lifecycle {


### PR DESCRIPTION
## what
- Conditionally configure default security group ingress only when `length(var.ingress_security_groups) > 0`

## why
- Otherwise, it detects an update on every plan run even if applied (which whould not do anythink because `security_groups` is empty). Ex:

	```
	Terraform will perform the following actions:
	
	  # module.ec2_bastion.aws_security_group.default[0] will be updated in-place
	  ~ resource "aws_security_group" "default" {
	        arn                    = "XXX"
	        description            = "Bastion security group (only SSH inbound access is allowed)"
	        egress                 = []
	        id                     = "XXX"
	      ~ ingress                = [
	            {
	                cidr_blocks      = [
	                    "0.0.0.0/0",
	                ]
	                description      = "Allow ingress to groups listed in var.allowed_cidr_blocks"
	                from_port        = 22
	                ipv6_cidr_blocks = []
	                prefix_list_ids  = []
	                protocol         = "tcp"
	                security_groups  = []
	                self             = false
	                to_port          = 22
	            },
	          + {
	              + cidr_blocks      = []
	              + description      = "Allow ingress to groups listed in var.ingress_security"
	              + from_port        = 0
	              + ipv6_cidr_blocks = []
	              + prefix_list_ids  = []
	              + protocol         = "-1"
	              + security_groups  = []
	              + self             = false
	              + to_port          = 0
	            },
	        ]
	        name                   = "a-bastion"
	        ...
	    }
	
	```

## references
