### PR TITLE
Support AWS provider v3

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws      = "~> 2.55"
+    aws      = ">= 2.55, <4.0"
     null     = "~> 2.1"
     template = "~> 2.1"
   }


### PR DESCRIPTION
## what
* Allow AWS provider version 3

## why
* Can sometimes block usage of another module requiring AWS v3 if used in conjunction

## references

