### PR TITLE
fix: use short hostname for dns record

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Available targets:
 | egress\_allowed | Allow all egress traffic from instance | `bool` | `false` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| host\_name | The Bastion hostname created in Route53 | `string` | `"bastion"` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | ingress\_security\_groups | AWS security group IDs allowed ingress to instance | `list(string)` | `[]` | no |
 | instance\_type | Bastion instance type | `string` | `"t2.micro"` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -29,6 +29,7 @@
 | egress\_allowed | Allow all egress traffic from instance | `bool` | `false` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| host\_name | The Bastion hostname created in Route53 | `string` | `"bastion"` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | ingress\_security\_groups | AWS security group IDs allowed ingress to instance | `list(string)` | `[]` | no |
 | instance\_type | Bastion instance type | `string` | `"t2.micro"` | no |

--- a/main.tf
+++ b/main.tf
@@ -127,11 +127,12 @@ resource "aws_instance" "default" {
 }
 
 module "dns" {
-  source  = "cloudposse/route53-cluster-hostname/aws"
-  version = "0.9.0"
-  enabled = module.this.enabled && var.zone_id != "" ? true : false
-  zone_id = var.zone_id
-  ttl     = 60
-  records = var.associate_public_ip_address ? aws_instance.default.*.public_dns : aws_instance.default.*.private_dns
-  context = module.this.context
+  source   = "cloudposse/route53-cluster-hostname/aws"
+  version  = "0.9.0"
+  enabled  = module.this.enabled && var.zone_id != "" ? true : false
+  zone_id  = var.zone_id
+  ttl      = 60
+  records  = var.associate_public_ip_address ? aws_instance.default.*.public_dns : aws_instance.default.*.private_dns
+  context  = module.this.context
+  dns_name = var.host_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -105,3 +105,9 @@ variable "egress_allowed" {
   default     = false
   description = "Allow all egress traffic from instance"
 }
+
+variable "host_name" {
+  type        = string
+  default     = "bastion"
+  description = "The Bastion hostname created in Route53"
+}


### PR DESCRIPTION
## what
* Add a `host_name` variable to revert the namechange introduced in `v0.17.0`.

## why
* Since [v0.17.0](https://github.com/cloudposse/terraform-aws-ec2-bastion-server/releases/tag/0.17.0) context is being passed to the `route53-cluster-hostname` module, which results in the hostname to be changed to the value of `module.this.id` (`namespace-env-bastion`) rather than `bastion`

## references
* As similarly applied to [terraform-aws-rds](https://github.com/cloudposse/terraform-aws-rds/pull/83)

