### PR TITLE
feat: use security-group module instead of resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,33 +105,32 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13.0 |
-| aws | >= 2.55 |
+| aws | >= 3.0 |
 | template | >= 2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.55 |
+| aws | >= 3.0 |
 | template | >= 2.1 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| additional\_security\_groups | List of additional Security Group IDs to be allowed to connect to EC2 instance | `list(string)` | `[]` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| allowed\_cidr\_blocks | A list of CIDR blocks allowed to connect | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | ami | AMI to use | `string` | `"ami-084ef34fdfdd7384c"` | no |
 | associate\_public\_ip\_address | Whether to associate a public IP to the instance. | `bool` | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| create\_security\_group | Create Security Group | `bool` | `true` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| egress\_allowed | Allow all egress traffic from instance | `bool` | `false` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | host\_name | The Bastion hostname created in Route53 | `string` | `"bastion"` | no |
 | id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| ingress\_security\_groups | AWS security group IDs allowed ingress to instance | `list(string)` | `[]` | no |
 | instance\_type | Bastion instance type | `string` | `"t2.micro"` | no |
 | key\_name | Key name | `string` | `""` | no |
 | label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
@@ -145,7 +144,8 @@ Available targets:
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | root\_block\_device\_encrypted | Whether to encrypt the root block device | `bool` | `true` | no |
 | root\_block\_device\_volume\_size | The volume size (in GiB) to provision for the root block device. It cannot be smaller than the AMI it refers to. | `number` | `8` | no |
-| security\_groups | AWS security group IDs associated with instance | `list(string)` | `[]` | no |
+| security\_group\_rules | A list of maps of Security Group rules. <br>The values of map is fully complated with `aws_security_group_rule` resource. <br>To get more info see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule . | `list(any)` | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": "Allow ALL egress traffic",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "to_port": 65535,<br>    "type": "egress"<br>  }<br>]</pre> | no |
+| security\_group\_use\_name\_prefix | Whether to create a default Security Group with unique name beginning with the normalized prefix. | `bool` | `false` | no |
 | ssh\_user | Default SSH user for this AMI. e.g. `ec2user` for Amazon Linux and `ubuntu` for Ubuntu systems | `string` | n/a | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | subnets | AWS subnet IDs | `list(string)` | n/a | yes |
@@ -163,7 +163,9 @@ Available targets:
 | private\_ip | Private IP of the instance |
 | public\_ip | Public IP of the instance (or EIP) |
 | role | Name of AWS IAM Role associated with the instance |
+| security\_group\_arn | Security Group ARN |
 | security\_group\_id | Security group ID |
+| security\_group\_name | Security Group name |
 | ssh\_user | SSH user |
 
 <!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,33 +4,32 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13.0 |
-| aws | >= 2.55 |
+| aws | >= 3.0 |
 | template | >= 2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.55 |
+| aws | >= 3.0 |
 | template | >= 2.1 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| additional\_security\_groups | List of additional Security Group IDs to be allowed to connect to EC2 instance | `list(string)` | `[]` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| allowed\_cidr\_blocks | A list of CIDR blocks allowed to connect | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | ami | AMI to use | `string` | `"ami-084ef34fdfdd7384c"` | no |
 | associate\_public\_ip\_address | Whether to associate a public IP to the instance. | `bool` | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| create\_security\_group | Create Security Group | `bool` | `true` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| egress\_allowed | Allow all egress traffic from instance | `bool` | `false` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | host\_name | The Bastion hostname created in Route53 | `string` | `"bastion"` | no |
 | id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| ingress\_security\_groups | AWS security group IDs allowed ingress to instance | `list(string)` | `[]` | no |
 | instance\_type | Bastion instance type | `string` | `"t2.micro"` | no |
 | key\_name | Key name | `string` | `""` | no |
 | label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
@@ -44,7 +43,8 @@
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | root\_block\_device\_encrypted | Whether to encrypt the root block device | `bool` | `true` | no |
 | root\_block\_device\_volume\_size | The volume size (in GiB) to provision for the root block device. It cannot be smaller than the AMI it refers to. | `number` | `8` | no |
-| security\_groups | AWS security group IDs associated with instance | `list(string)` | `[]` | no |
+| security\_group\_rules | A list of maps of Security Group rules. <br>The values of map is fully complated with `aws_security_group_rule` resource. <br>To get more info see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule . | `list(any)` | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": "Allow ALL egress traffic",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "to_port": 65535,<br>    "type": "egress"<br>  }<br>]</pre> | no |
+| security\_group\_use\_name\_prefix | Whether to create a default Security Group with unique name beginning with the normalized prefix. | `bool` | `false` | no |
 | ssh\_user | Default SSH user for this AMI. e.g. `ec2user` for Amazon Linux and `ubuntu` for Ubuntu systems | `string` | n/a | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | subnets | AWS subnet IDs | `list(string)` | n/a | yes |
@@ -62,7 +62,9 @@
 | private\_ip | Private IP of the instance |
 | public\_ip | Public IP of the instance (or EIP) |
 | role | Name of AWS IAM Role associated with the instance |
+| security\_group\_arn | Security Group ARN |
 | security\_group\_id | Security group ID |
+| security\_group\_name | Security Group name |
 | ssh\_user | SSH user |
 
 <!-- markdownlint-restore -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -42,11 +42,28 @@ module "ec2_bastion" {
   ami           = var.ami
   instance_type = var.instance_type
 
-  security_groups         = compact(concat([module.vpc.vpc_default_security_group_id], var.security_groups))
-  ingress_security_groups = var.ingress_security_groups
-  subnets                 = module.subnets.public_subnet_ids
-  ssh_user                = var.ssh_user
-  key_name                = module.aws_key_pair.key_name
+  security_group_rules = [
+    {
+      type        = "egress"
+      from_port   = 0
+      to_port     = 65535
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow ALL egress traffic"
+    },
+    {
+      type                     = "ingress"
+      from_port                = 0
+      to_port                  = 65535
+      protocol                 = "-1"
+      source_security_group_id = [module.vpc.vpc_default_security_group_id]
+      description              = "Allow ALL ingress traffic from trusted Security Groups"
+    },
+  ]
+
+  subnets  = module.subnets.public_subnet_ids
+  ssh_user = var.ssh_user
+  key_name = module.aws_key_pair.key_name
 
   user_data = var.user_data
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -47,25 +47,6 @@ variable "generate_ssh_key" {
   description = "Whether or not to generate an SSH key"
 }
 
-variable "security_groups" {
-  type        = list(string)
-  description = "AWS security group IDs"
-}
-
-variable "ingress_security_groups" {
-  type        = list(string)
-  description = "AWS security group IDs allowed ingress to instance"
-}
-
-variable "allowed_cidr_blocks" {
-  type        = list(string)
-  description = "A list of CIDR blocks allowed to connect"
-
-  default = [
-    "0.0.0.0/0",
-  ]
-}
-
 variable "root_block_device_encrypted" {
   type        = bool
   default     = false

--- a/examples/latest-ami/main.tf
+++ b/examples/latest-ami/main.tf
@@ -67,11 +67,28 @@ module "ec2_bastion" {
   tags       = var.tags
   attributes = var.attributes
 
-  security_groups         = compact(concat([module.vpc.vpc_default_security_group_id], var.security_groups))
-  ingress_security_groups = var.ingress_security_groups
-  subnets                 = module.subnets.public_subnet_ids
-  ssh_user                = var.ssh_user
-  key_name                = module.aws_key_pair.key_name
+  security_group_rules = [
+    {
+      type        = "egress"
+      from_port   = 0
+      to_port     = 65535
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow ALL egress traffic"
+    },
+    {
+      type                     = "ingress"
+      from_port                = 0
+      to_port                  = 65535
+      protocol                 = "-1"
+      source_security_group_id = [module.vpc.vpc_default_security_group_id]
+      description              = "Allow ALL ingress traffic from trusted Security Groups"
+    },
+  ]
+
+  subnets  = module.subnets.public_subnet_ids
+  ssh_user = var.ssh_user
+  key_name = module.aws_key_pair.key_name
 
   user_data = var.user_data
 

--- a/examples/latest-ami/variables.tf
+++ b/examples/latest-ami/variables.tf
@@ -79,25 +79,6 @@ variable "generate_ssh_key" {
   description = "Whether or not to generate an SSH key"
 }
 
-variable "security_groups" {
-  type        = list(string)
-  description = "AWS security group IDs"
-}
-
-variable "ingress_security_groups" {
-  type        = list(string)
-  description = "AWS security group IDs allowed ingress to instance"
-}
-
-variable "allowed_cidr_blocks" {
-  type        = list(string)
-  description = "A list of CIDR blocks allowed to connect"
-
-  default = [
-    "0.0.0.0/0",
-  ]
-}
-
 variable "root_block_device_encrypted" {
   type        = bool
   default     = false

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  security_group_enabled = module.this.enabled && var.create_default_security_group ? true : false
+}
+
 resource "aws_iam_instance_profile" "default" {
   count = module.this.enabled ? 1 : 0
   name  = module.this.id
@@ -30,53 +34,17 @@ data "aws_iam_policy_document" "default" {
   }
 }
 
-resource "aws_security_group" "default" {
-  count       = module.this.enabled ? 1 : 0
-  name        = module.this.id
-  vpc_id      = var.vpc_id
-  description = "Bastion host security group"
+module "default_sg" {
+  source          = "cloudposse/security-group/aws"
+  version         = "0.1.2"
+  use_name_prefix = var.security_group_use_name_prefix
+  rules           = var.security_group_rules
+  vpc_id          = var.vpc_id
+  description     = "Bastion host security group"
 
-  tags = module.this.tags
-
-  # Optional block; skipped if var.allowed_cidr_blocks is empty
-  dynamic "ingress" {
-    for_each = length(var.allowed_cidr_blocks) > 0 ? [1] : []
-    content {
-      protocol    = "tcp"
-      from_port   = 22
-      to_port     = 22
-      cidr_blocks = var.allowed_cidr_blocks
-      description = "Allow SSH ingress traffic from trusted CIDR Blocks"
-    }
-  }
-
-  # Optional block; skipped if var.ingress_security_groups is empty
-  dynamic "ingress" {
-    for_each = length(var.ingress_security_groups) > 0 ? [1] : []
-    content {
-      from_port       = 0
-      to_port         = 0
-      protocol        = -1
-      security_groups = var.ingress_security_groups
-      description     = "Allow ALL ingress traffic from trusted Security Groups"
-    }
-  }
-
-  # Optional block; skipped unless var.egress_allowed is set to true
-  dynamic "egress" {
-    for_each = var.egress_allowed ? [1] : []
-    content {
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
-      description = "Allow ALL egress traffic"
-    }
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
+  enabled = local.security_group_enabled
+  name    = module.this.id
+  context = module.this.context
 }
 
 data "aws_route53_zone" "domain" {
@@ -106,7 +74,12 @@ resource "aws_instance" "default" {
 
   user_data = data.template_file.user_data[0].rendered
 
-  vpc_security_group_ids = compact(concat(aws_security_group.default.*.id, var.security_groups))
+  vpc_security_group_ids = compact(
+    sort(concat(
+      [module.default_sg.id],
+      var.additional_security_groups
+    ))
+  )
 
   iam_instance_profile        = aws_iam_instance_profile.default[0].name
   associate_public_ip_address = var.associate_public_ip_address

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,8 +9,18 @@ output "ssh_user" {
 }
 
 output "security_group_id" {
-  value       = join("", aws_security_group.default.*.id)
+  value       = module.default_sg.id
   description = "Security group ID"
+}
+
+output "security_group_arn" {
+  value       = module.default_sg.arn
+  description = "Security Group ARN"
+}
+
+output "security_group_name" {
+  value       = module.default_sg.name
+  description = "Security Group name"
 }
 
 output "role" {

--- a/variables.tf
+++ b/variables.tf
@@ -43,25 +43,41 @@ variable "ssh_user" {
   description = "Default SSH user for this AMI. e.g. `ec2user` for Amazon Linux and `ubuntu` for Ubuntu systems"
 }
 
-variable "ingress_security_groups" {
-  type        = list(string)
-  description = "AWS security group IDs allowed ingress to instance"
-  default     = []
+variable "create_security_group" {
+  type        = bool
+  description = "Create Security Group"
+  default     = true
 }
 
-variable "security_groups" {
-  type        = list(string)
-  description = "AWS security group IDs associated with instance"
-  default     = []
-}
-
-variable "allowed_cidr_blocks" {
-  type        = list(string)
-  description = "A list of CIDR blocks allowed to connect"
-
+variable "security_group_rules" {
+  type = list(any)
   default = [
-    "0.0.0.0/0",
+    {
+      type        = "egress"
+      from_port   = 0
+      to_port     = 65535
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow ALL egress traffic"
+    }
   ]
+  description = <<-EOT
+    A list of maps of Security Group rules. 
+    The values of map is fully complated with `aws_security_group_rule` resource. 
+    To get more info see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule .
+  EOT
+}
+
+variable "security_group_use_name_prefix" {
+  type        = bool
+  default     = false
+  description = "Whether to create a default Security Group with unique name beginning with the normalized prefix."
+}
+
+variable "additional_security_groups" {
+  description = "List of additional Security Group IDs to be allowed to connect to EC2 instance"
+  type        = list(string)
+  default     = []
 }
 
 variable "root_block_device_encrypted" {
@@ -98,12 +114,6 @@ variable "associate_public_ip_address" {
   type        = bool
   default     = true
   description = "Whether to associate a public IP to the instance."
-}
-
-variable "egress_allowed" {
-  type        = bool
-  default     = false
-  description = "Allow all egress traffic from instance"
 }
 
 variable "host_name" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.55"
+      version = ">= 3.0"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
## what
* use security-group module instead of resource

## why
* more flexible  than current implementation 
* bring configuration of security group/rules to one standard

## references
* CPCO-409

