### PR TITLE
fix: bastion eip association

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Available targets:
 | Name | Type |
 |------|------|
 | [aws_eip.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
-| [aws_eip_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Available targets:
 | Name | Type |
 |------|------|
 | [aws_eip.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_eip_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
@@ -220,8 +221,6 @@ Check out these related projects.
 - [bastion](https://github.com/cloudposse/bastion) - 🔒Secure Bastion implemented as Docker Container running Alpine Linux with Google Authenticator & DUO MFA support
 - [terraform-aws-ec2-instance](https://github.com/cloudposse/terraform-aws-ec2-instance) - Terraform module for providing a general EC2 instance provisioned by Ansible
 - [terraform-aws-ec2-ami-backup](https://github.com/cloudposse/terraform-aws-ec2-ami-backup) - Terraform module for automatic & scheduled AMI creation
-
-
 
 ## Help
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,6 +27,7 @@
 | Name | Type |
 |------|------|
 | [aws_eip.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_eip_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,7 +27,6 @@
 | Name | Type |
 |------|------|
 | [aws_eip.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
-| [aws_eip_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |

--- a/main.tf
+++ b/main.tf
@@ -95,15 +95,10 @@ resource "aws_instance" "default" {
 }
 
 resource "aws_eip" "default" {
-  count = local.eip_enabled ? 1 : 0
-  vpc   = true
-  tags  = module.this.tags
-}
-
-resource "aws_eip_association" "default" {
-  count         = local.eip_enabled ? 1 : 0
-  instance_id   = aws_instance.default[0].id
-  allocation_id = aws_eip.default[0].id
+  count    = local.eip_enabled ? 1 : 0
+  instance = join("", aws_instance.default.*.id)
+  vpc      = true
+  tags     = module.this.tags
 }
 
 module "dns" {

--- a/main.tf
+++ b/main.tf
@@ -95,10 +95,15 @@ resource "aws_instance" "default" {
 }
 
 resource "aws_eip" "default" {
-  count             = local.eip_enabled ? 1 : 0
-  network_interface = join("", aws_instance.default.*.primary_network_interface_id)
-  vpc               = true
-  tags              = module.this.tags
+  count = local.eip_enabled ? 1 : 0
+  vpc   = true
+  tags  = module.this.tags
+}
+
+resource "aws_eip_association" "default" {
+  count         = local.eip_enabled ? 1 : 0
+  instance_id   = aws_instance.default.id
+  allocation_id = aws_eip.default.id
 }
 
 module "dns" {

--- a/main.tf
+++ b/main.tf
@@ -102,8 +102,8 @@ resource "aws_eip" "default" {
 
 resource "aws_eip_association" "default" {
   count         = local.eip_enabled ? 1 : 0
-  instance_id   = aws_instance.default.id
-  allocation_id = aws_eip.default.id
+  instance_id   = aws_instance.default[0].id
+  allocation_id = aws_eip.default[0].id
 }
 
 module "dns" {


### PR DESCRIPTION
## what
* Associate the EIP to the appropriate instance

## why
* Otherwise it tries to assign the EIP to the terminated instance, which results in a failed apply.

## references
* closes #70

