### PR TITLE
Fix conditional logic for creating IAM role 

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,8 +357,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Bobby Larson][karma0_avatar]][karma0_homepage]<br/>[Bobby Larson][karma0_homepage] | [![Vladimir Syromyatnikov][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir Syromyatnikov][SweetOps_homepage] |
-|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Bobby Larson][karma0_avatar]][karma0_homepage]<br/>[Bobby Larson][karma0_homepage] | [![Vladimir Syromyatnikov][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir Syromyatnikov][SweetOps_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] |
+|---|---|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -371,6 +371,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [karma0_avatar]: https://img.cloudposse.com/150x150/https://github.com/karma0.png
   [SweetOps_homepage]: https://github.com/SweetOps
   [SweetOps_avatar]: https://img.cloudposse.com/150x150/https://github.com/SweetOps.png
+  [korenyoni_homepage]: https://github.com/korenyoni
+  [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -56,3 +56,5 @@ contributors:
     github: "karma0"
   - name: "Vladimir Syromyatnikov"
     github: "SweetOps"
+  - name: "Yonatan Koren"
+    github: "korenyoni"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "0.18.1"
+  version = "0.25.0"
 
   cidr_block = "172.16.0.0/16"
 
@@ -13,7 +13,7 @@ module "vpc" {
 
 module "subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.33.0"
+  version              = "0.39.3"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id
@@ -26,7 +26,7 @@ module "subnets" {
 
 module "aws_key_pair" {
   source              = "cloudposse/key-pair/aws"
-  version             = "0.16.1"
+  version             = "0.18.0"
   attributes          = ["ssh", "key"]
   ssh_public_key_path = var.ssh_key_path
   generate_ssh_key    = var.generate_ssh_key

--- a/iam.tf
+++ b/iam.tf
@@ -1,12 +1,12 @@
 resource "aws_iam_instance_profile" "default" {
-  count = (module.this.enabled && local.instance_profile_count == 0) ? 0 : 1
+  count = module.this.enabled && local.create_instance_profile ? 1 : 0
   name  = module.this.id
   role  = aws_iam_role.default[0].name
   tags  = module.this.tags
 }
 
 resource "aws_iam_role" "default" {
-  count = (module.this.enabled && local.instance_profile_count == 0) ? 0 : 1
+  count = module.this.enabled && local.create_instance_profile ? 1 : 0
   name  = module.this.id
   path  = "/"
   tags  = module.this.tags
@@ -15,7 +15,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_iam_role_policy" "main" {
-  count  = (module.this.enabled && local.instance_profile_count == 0) ? 0 : 1
+  count = module.this.enabled && local.create_instance_profile ? 1 : 0
   name   = module.this.id
   role   = aws_iam_role.default[0].id
   policy = data.aws_iam_policy_document.main.json

--- a/iam.tf
+++ b/iam.tf
@@ -15,7 +15,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_iam_role_policy" "main" {
-  count = module.this.enabled && local.create_instance_profile ? 1 : 0
+  count  = module.this.enabled && local.create_instance_profile ? 1 : 0
   name   = module.this.id
   role   = aws_iam_role.default[0].id
   policy = data.aws_iam_policy_document.main.json

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 locals {
-  instance_profile_count = module.this.enabled ? (length(var.instance_profile) > 0 ? 0 : 1) : 0
-  instance_profile       = local.instance_profile_count == 0 ? var.instance_profile : join("", aws_iam_instance_profile.default.*.name)
-  eip_enabled            = var.associate_public_ip_address && var.assign_eip_address && module.this.enabled
-  security_group_enabled = module.this.enabled && var.security_group_enabled
-  public_dns             = local.eip_enabled ? local.public_dns_rendered : join("", aws_instance.default.*.public_dns)
+  create_instance_profile = module.this.enabled && try(length(var.instance_profile), 0) == 0
+  instance_profile        = local.create_instance_profile ? var.instance_profile : join("", aws_iam_instance_profile.default.*.name)
+  eip_enabled             = var.associate_public_ip_address && var.assign_eip_address && module.this.enabled
+  security_group_enabled  = module.this.enabled && var.security_group_enabled
+  public_dns              = local.eip_enabled ? local.public_dns_rendered : join("", aws_instance.default.*.public_dns)
   public_dns_rendered = local.eip_enabled ? format("ec2-%s.%s.amazonaws.com",
     replace(join("", aws_eip.default.*.public_ip), ".", "-"),
     data.aws_region.default.name == "us-east-1" ? "compute-1" : format("%s.compute", data.aws_region.default.name)

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -55,7 +55,7 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	keyName := terraform.Output(t, terraformOptions, "key_name")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-ec2-bastion-ssh-key-"+randID, keyName)
+	assert.Equal(t, "eg-test-ec2-bastion-" + randID + "-ssh-key", keyName)
 
 	// Run `terraform output` to get the value of an output variable
 	privateDns := terraform.Output(t, terraformOptions, "private_dns")


### PR DESCRIPTION
## what
* Fix conditional logic for creating IAM role

## why
* IAM Role was being created even when `var.enabled=false`
* Bump modules in `examples/complete`.

## references
* Issue identified in https://github.com/cloudposse/terraform-aws-components/pull/340

