### PR TITLE
Feature/remove template provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,12 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.55 |
-| <a name="provider_template"></a> [template](#provider\_template) | >= 2.1 |
 
 ## Modules
 
@@ -135,7 +133,6 @@ Available targets:
 | [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [template_file.user_data](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,14 +5,12 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.55 |
-| <a name="provider_template"></a> [template](#provider\_template) | >= 2.1 |
 
 ## Modules
 
@@ -36,7 +34,6 @@
 | [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [template_file.user_data](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.55"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.1"
-    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -47,10 +47,10 @@ data "aws_route53_zone" "domain" {
 resource "aws_instance" "default" {
   #bridgecrew:skip=BC_AWS_PUBLIC_12: Skipping `EC2 Should Not Have Public IPs` check. NAT instance requires public IP.
   #bridgecrew:skip=BC_AWS_GENERAL_31: Skipping `Ensure Instance Metadata Service Version 1 is not enabled` check until BridgeCrew support condition evaluation. See https://github.com/bridgecrewio/checkov/issues/793
-  count                       = module.this.enabled ? 1 : 0
-  ami                         = data.aws_ami.default.id
-  instance_type               = var.instance_type
-  user_data                   = length(var.user_data_base64) > 0 ? var.user_data_base64 : templatefile("${path.module}/${var.user_data_template}", {
+  count         = module.this.enabled ? 1 : 0
+  ami           = data.aws_ami.default.id
+  instance_type = var.instance_type
+  user_data = length(var.user_data_base64) > 0 ? var.user_data_base64 : templatefile("${path.module}/${var.user_data_template}", {
     user_data   = join("\n", var.user_data)
     ssm_enabled = var.ssm_enabled
     ssh_user    = var.ssh_user

--- a/versions.tf
+++ b/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.55"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.1"
-    }
   }
 }


### PR DESCRIPTION
## what
* Remove unused and deprecated template provider
* Replace `template_file` datasource by `templatefile` function

## why
* hashicorp/template is now deprecated
* hashicorp/template has not been compiled and shared for M1 processors (Macbook Air M1, Macbook Pro, ...)

## references
* [https://registry.terraform.io/providers/hashicorp/template/latest/docs]()