### PR TITLE
git.io->cloudposse.tools update, Lock down CODEOWNERS

### DIFF
--- a/.github/.github-CODEOWNERS-update-disabled
+++ b/.github/.github-CODEOWNERS-update-disabled
@@ -1,0 +1,7 @@
+This presence of a .github/.github-CODEOWNERS-update-disabled file
+prevents `make github/update` from modifying the CODEOWNERS file
+while allowing all other `github/update` changes to proceed.
+You can prevent all `github/update` changes, including changes to CODEOWNERS,
+by adding a .github/.github-update-disabled file, in which case
+a .github/.github-CODEOWNERS-update-disabled file is redundant.
+The contents of these files are ignored, only their presence or absence matters.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,23 +3,9 @@
 #
 # Order is important: the last matching pattern has the highest precedence
 
+# LOCKDOWN for Security Groups
+# ec2-bastion-server is on lockdown until it is updated to use 
+# cloudposse/terraform-aws-security-group v0.4.3 or later
+
 # These owners will be the default owners for everything
-*             @cloudposse/engineering @cloudposse/contributors
-
-# Cloud Posse must review any changes to Makefiles
-**/Makefile   @cloudposse/engineering
-**/Makefile.* @cloudposse/engineering
-
-# Cloud Posse must review any changes to GitHub actions
-.github/*     @cloudposse/engineering
-
-# Cloud Posse must review any changes to standard context definition,
-# but some changes can be rubber-stamped.
-**/*.tf       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
-README.yaml   @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
-README.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
-docs/*.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
-
-# Cloud Posse Admins must review all changes to CODEOWNERS or the mergify configuration
-.github/mergify.yml @cloudposse/admins
-.github/CODEOWNERS  @cloudposse/admins
+*             @cloudposse/admins

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Create Pull Request
       if: steps.update.outputs.create_pull_request == 'true'
-      uses: cloudposse/actions/github/create-pull-request@0.22.0
+      uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -62,7 +62,7 @@ jobs:
         fi
 
     - name: Auto Test
-      uses: cloudposse/actions/github/repository-dispatch@0.22.0
+      uses: cloudposse/actions/github/repository-dispatch@0.30.0
       # match users by ID because logins (user names) are inconsistent,
       # for example in the REST API Renovate Bot is `renovate[bot]` but
       # in GraphQL it is just `renovate`, plus there is a non-bot

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,0 +1,71 @@
+name: "auto-readme"
+on:
+  workflow_dispatch:
+
+  schedule:
+  # Example of job definition:
+  # .---------------- minute (0 - 59)
+  # |  .------------- hour (0 - 23)
+  # |  |  .---------- day of month (1 - 31)
+  # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+  # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+  # |  |  |  |  |
+  # *  *  *  *  * user-name command to be executed
+
+  # Update README.md nightly at 4am UTC
+  - cron:  '0 4 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Find default branch name
+      id: defaultBranch
+      shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        printf "defaultBranchRef.name=%s\n" "${default_branch}"
+
+    - name: Update readme
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DEF: "${{ steps.defaultBranch.outputs.defaultBranch }}"
+      run: |
+        make init
+        make readme/build
+        # Ignore changes if they are only whitespace
+        if ! git diff --quiet README.md && git diff --ignore-all-space --ignore-blank-lines --quiet README.md; then
+          git restore README.md
+          echo Ignoring whitespace-only changes in README
+        fi
+
+    - name: Create Pull Request
+      # This action will not create or change a pull request if there are no changes to make.
+      # If a PR of the auto-update/readme branch is open, this action will just update it, not create a new PR.
+      uses: cloudposse/actions/github/create-pull-request@0.30.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update README.md and docs
+        title: Update README.md and docs
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the README.md and docs
+
+          ## why
+          To have most recent changes of README.md and doc from origin templates
+
+        branch: auto-update/readme
+        base: ${{ steps.defaultBranch.outputs.defaultBranch }}
+        delete-branch: true
+        labels: |
+          auto-update
+          no-release
+          readme

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Handle common commands"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       - name: "Checkout commit"
         uses: actions/checkout@v2
       - name: "Run tests"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -18,10 +18,12 @@ jobs:
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
         #   checks: "files,syntax,owners,duppatterns"
         checks: "syntax,owners,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md docs/terraform.md
 
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 
 ## Lint terraform code
 lint:


### PR DESCRIPTION
## what and why
1. Change all references to `git.io/build-harness` into `cloudposse.tools/build-harness`, since `git.io` redirects will stop working on April 29th, 2022.
2. Lock down this repo via CODEOWNERS until [breaking changes from v0.28.0](https://github.com/cloudposse/terraform-aws-ec2-bastion-server/releases/tag/0.28.0) are reverted, to avoid publishing new releases that perpetuate the breaking changes.

## References
- DEV-143