### PR TITLE
In main.tf : resource aws_eip replace deprecated vpc argument by domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "aws_instance" "default" {
 resource "aws_eip" "default" {
   count    = local.eip_enabled ? 1 : 0
   instance = join("", aws_instance.default.*.id)
-  vpc      = true
+  domain   = "vpc"
   tags     = module.this.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "aws_instance" "default" {
 
 resource "aws_eip" "default" {
   count    = local.eip_enabled ? 1 : 0
-  instance = join("", aws_instance.default.*.id)
+  instance = join("", aws_instance.default[*].id)
   domain   = "vpc"
   tags     = module.this.tags
 }


### PR DESCRIPTION
## what

Remove deprecated argument in resource aws_eip and replace it with the new argument recommended by Hashicorp AWS provider.

## why

To remove terraform warning when plan or apply stack and to be up to date.

## references

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip
