### PR TITLE
Support AWS Provider V5

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,25 +3,22 @@ provider "aws" {
 }
 
 module "vpc" {
-  source  = "cloudposse/vpc/aws"
-  version = "0.25.0"
-
-  cidr_block = "172.16.0.0/16"
-
-  context = module.this.context
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.1.0"
+  ipv4_primary_cidr_block = var.vpc_cidr_block
+  context                 = module.this.context
 }
 
 module "subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.39.3"
+  version              = "2.3.0"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
+  igw_id               = [module.vpc.igw_id]
+  ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = false
   nat_instance_enabled = false
-
-  context = module.this.context
+  context              = module.this.context
 }
 
 module "aws_key_pair" {

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,11 @@
 locals {
   create_instance_profile = module.this.enabled && try(length(var.instance_profile), 0) == 0
-  instance_profile        = local.create_instance_profile ? join("", aws_iam_instance_profile.default.*.name) : var.instance_profile
+  instance_profile        = local.create_instance_profile ? join("", aws_iam_instance_profile.default[*].name) : var.instance_profile
   eip_enabled             = var.associate_public_ip_address && var.assign_eip_address && module.this.enabled
   security_group_enabled  = module.this.enabled && var.security_group_enabled
-  public_dns              = local.eip_enabled ? local.public_dns_rendered : join("", aws_instance.default.*.public_dns)
+  public_dns              = local.eip_enabled ? local.public_dns_rendered : join("", aws_instance.default[*].public_dns)
   public_dns_rendered = local.eip_enabled ? format("ec2-%s.%s.amazonaws.com",
-    replace(join("", aws_eip.default.*.public_ip), ".", "-"),
+    replace(join("", aws_eip.default[*].public_ip), ".", "-"),
     data.aws_region.default.name == "us-east-1" ? "compute-1" : format("%s.compute", data.aws_region.default.name)
   ) : null
   user_data_templated = templatefile("${path.module}/${var.user_data_template}", {
@@ -55,10 +55,10 @@ resource "aws_instance" "default" {
   #bridgecrew:skip=BC_AWS_PUBLIC_12: Skipping `EC2 Should Not Have Public IPs` check. NAT instance requires public IP.
   #bridgecrew:skip=BC_AWS_GENERAL_31: Skipping `Ensure Instance Metadata Service Version 1 is not enabled` check until BridgeCrew support condition evaluation. See https://github.com/bridgecrewio/checkov/issues/793
   count                       = module.this.enabled ? 1 : 0
-  ami                         = coalesce(var.ami, join("", data.aws_ami.default.*.id))
+  ami                         = coalesce(var.ami, join("", data.aws_ami.default[*].id))
   instance_type               = var.instance_type
   user_data                   = length(var.user_data_base64) > 0 ? var.user_data_base64 : local.user_data_templated
-  vpc_security_group_ids      = compact(concat(module.security_group.*.id, var.security_groups))
+  vpc_security_group_ids      = compact(concat(module.security_group[*].id, var.security_groups))
   iam_instance_profile        = local.instance_profile
   associate_public_ip_address = var.associate_public_ip_address
   key_name                    = var.key_name
@@ -94,7 +94,7 @@ resource "aws_instance" "default" {
 
 resource "aws_eip" "default" {
   count    = local.eip_enabled ? 1 : 0
-  instance = join("", aws_instance.default.*.id)
+  instance = join("", aws_instance.default[*].id)
   vpc      = true
   tags     = module.this.tags
 }
@@ -105,7 +105,7 @@ module "dns" {
   enabled  = module.this.enabled && try(length(var.zone_id), 0) > 0 ? true : false
   zone_id  = var.zone_id
   ttl      = 60
-  records  = var.associate_public_ip_address ? tolist([local.public_dns]) : tolist([join("", aws_instance.default.*.private_dns)])
+  records  = var.associate_public_ip_address ? tolist([local.public_dns]) : tolist([join("", aws_instance.default[*].private_dns)])
   context  = module.this.context
   dns_name = var.host_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "instance_id" {
-  value       = join("", aws_instance.default.*.id)
+  value       = join("", aws_instance.default[*].id)
   description = "Instance ID"
 }
 
@@ -19,23 +19,23 @@ output "security_group_ids" {
 }
 
 output "role" {
-  value       = join("", aws_iam_role.default.*.name)
+  value       = join("", aws_iam_role.default[*].name)
   description = "Name of AWS IAM Role associated with the instance"
 }
 
 output "public_ip" {
-  value       = concat(aws_eip.default.*.public_ip, aws_instance.default.*.public_ip, [""])[0]
+  value       = concat(aws_eip.default[*].public_ip, aws_instance.default[*].public_ip, [""])[0]
   description = "Public IP of the instance (or EIP)"
 }
 
 output "private_ip" {
-  value       = join("", aws_instance.default.*.private_ip)
+  value       = join("", aws_instance.default[*].private_ip)
   description = "Private IP of the instance"
 }
 
 output "private_dns" {
   description = "Private DNS of instance"
-  value       = join("", aws_instance.default.*.private_dns)
+  value       = join("", aws_instance.default[*].private_dns)
 }
 
 output "public_dns" {
@@ -50,12 +50,12 @@ output "hostname" {
 
 output "id" {
   description = "Disambiguated ID of the instance"
-  value       = join("", aws_instance.default.*.id)
+  value       = join("", aws_instance.default[*].id)
 }
 
 output "arn" {
   description = "ARN of the instance"
-  value       = join("", aws_instance.default.*.arn)
+  value       = join("", aws_instance.default[*].arn)
 }
 
 output "name" {


### PR DESCRIPTION
## what

Support AWS Provider V5
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
