### PR TITLE
Remove deprecated argument "vpc"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,6 @@ resource "aws_instance" "default" {
 resource "aws_eip" "default" {
   count    = local.eip_enabled ? 1 : 0
   instance = join("", aws_instance.default[*].id)
-  vpc      = true
   tags     = module.this.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "aws_instance" "default" {
 resource "aws_eip" "default" {
   count    = local.eip_enabled ? 1 : 0
   instance = join("", aws_instance.default.*.id)
-  vpc      = true
+  domain   = "vpc"
   tags     = module.this.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,6 @@ resource "aws_instance" "default" {
 resource "aws_eip" "default" {
   count    = local.eip_enabled ? 1 : 0
   instance = join("", aws_instance.default.*.id)
-  domain   = "vpc"
   tags     = module.this.tags
 }
 


### PR DESCRIPTION
## what

Remove the deprecated `vpc` argument to fix the warning. The `vpc` parameter has been deprecated since the AWS provider version 5.0, there's no need to explicitly specify either `vpc` or `domain`. Simply omitting it and using the default value will ensure optimal compatibility.

![image](https://github.com/cloudposse/terraform-aws-ec2-bastion-server/assets/2561450/07778523-7e5e-406c-83c9-f8b96f3230b8)

## references

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip#vpc
